### PR TITLE
Add alias to delete all merge branches locally

### DIFF
--- a/zsh/git.zsh
+++ b/zsh/git.zsh
@@ -4,6 +4,8 @@ alias gs='git status'
 alias gco='g checkout'
 alias gpush='g push origin $(current_branch)'
 
+alias gprune='git branch --merged | egrep -v "(^\*|master|dev|develop|development)" | xargs git branch -d'
+
 function g() {
     if [[ $# > 0 ]]; then
         # if there are arguments, send them to git


### PR DESCRIPTION
## What happened

Add alias `gprune` to delete all merge branches locally
 
## Insight

Taken from https://stackoverflow.com/questions/6127328/how-can-i-delete-all-git-branches-which-have-been-merged
 
## Proof Of Work

![compass___volumes_workspace_compass__-______github_pull_request_template_md](https://user-images.githubusercontent.com/696529/52252174-87355100-2933-11e9-9432-98e9c894a148.png) 