### PR TITLE
Add alias to stop all running Docker containers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 /test/tmp/
 /test/version_tmp/
 /tmp/
+.idea/
 
 # Used by dotenv library to load environment variables.
 # .env

--- a/zsh/aliases.zsh
+++ b/zsh/aliases.zsh
@@ -46,5 +46,8 @@ alias b="bundle"
 alias migrate="rake db:migrate db:rollback && rake db:migrate db:test:prepare"
 alias s="rspec"
 
+# Docker
+alias dstop='docker kill $(docker ps -q)'
+
 # Include custom aliases
 [[ -f ~/.aliases.local ]] && source ~/.aliases.local


### PR DESCRIPTION
## What happened

Simple alias to stop all running containers without having to first find which ones are running then stopping them.
 
## Insight

Found as a Gist: https://gist.github.com/evanscottgray/8571828
 
## Proof Of Work

![2562-03-15 08 32 17](https://user-images.githubusercontent.com/696529/54402016-e473ad80-46fc-11e9-84fb-8a614a005460.gif)
 